### PR TITLE
Improved Bake performance, 100x faster bake times, by eliminating unnecessary objects from the bake process.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportInvalidTypeForm": "none"
+  }
+}

--- a/__init__.py
+++ b/__init__.py
@@ -7,6 +7,150 @@ from mathutils import Vector, Matrix, Euler, Quaternion, geometry
 from bpy.app.handlers import persistent
 from gpu_extras.batch import batch_for_shader
 
+# For debugging the NLA Bake operation
+import time
+from bpy.app.handlers import persistent
+
+class BakeDebugger:
+    def __init__(self):
+        self.log_entries = []
+        self.start_time = None
+        self.frame_times = {}
+        self.object_evaluations = {}
+        self.modifier_evaluations = {}
+        
+    def start_logging(self):
+        self.log_entries = []
+        self.start_time = time.time()
+        self.frame_times = {}
+        self.object_evaluations = {}
+        self.modifier_evaluations = {}
+        self.log("=== STARTING NLA BAKE DEBUG SESSION ===")
+        
+    def log(self, message):
+        timestamp = time.time() - self.start_time if self.start_time else 0
+        entry = f"[{timestamp:.3f}s] {message}"
+        self.log_entries.append(entry)
+        print(entry)  # Also print to console
+        
+    def log_frame_start(self, frame):
+        self.frame_start_time = time.time()
+        self.log(f"--- FRAME {frame} START ---")
+        
+    def log_frame_end(self, frame):
+        frame_duration = time.time() - self.frame_start_time
+        self.frame_times[frame] = frame_duration
+        self.log(f"--- FRAME {frame} END ({frame_duration:.3f}s) ---")
+        
+    def log_object_evaluation(self, obj_name, obj_type):
+        if obj_name not in self.object_evaluations:
+            self.object_evaluations[obj_name] = 0
+        self.object_evaluations[obj_name] += 1
+        self.log(f"EVALUATING OBJECT: {obj_name} ({obj_type})")
+        
+    def log_modifier_evaluation(self, obj_name, mod_name, mod_type):
+        key = f"{obj_name}.{mod_name}"
+        if key not in self.modifier_evaluations:
+            self.modifier_evaluations[key] = 0
+        self.modifier_evaluations[key] += 1
+        self.log(f"EVALUATING MODIFIER: {obj_name}.{mod_name} ({mod_type})")
+        
+    def generate_report(self):
+        total_time = time.time() - self.start_time if self.start_time else 0
+        
+        report = []
+        report.append("=== NLA BAKE PERFORMANCE REPORT ===")
+        report.append(f"Total bake time: {total_time:.3f}s")
+        report.append("")
+        
+        # Frame timing analysis
+        if self.frame_times:
+            report.append("FRAME TIMING:")
+            avg_frame_time = sum(self.frame_times.values()) / len(self.frame_times)
+            slowest_frame = max(self.frame_times.items(), key=lambda x: x[1])
+            fastest_frame = min(self.frame_times.items(), key=lambda x: x[1])
+            
+            report.append(f"  Average frame time: {avg_frame_time:.3f}s")
+            report.append(f"  Slowest frame: {slowest_frame[0]} ({slowest_frame[1]:.3f}s)")
+            report.append(f"  Fastest frame: {fastest_frame[0]} ({fastest_frame[1]:.3f}s)")
+            report.append("")
+        
+        # Object evaluation analysis
+        if self.object_evaluations:
+            report.append("MOST EVALUATED OBJECTS:")
+            sorted_objects = sorted(self.object_evaluations.items(), key=lambda x: x[1], reverse=True)
+            for obj_name, count in sorted_objects[:20]:  # Top 20
+                report.append(f"  {obj_name}: {count} evaluations")
+            report.append("")
+        
+        # Modifier evaluation analysis
+        if self.modifier_evaluations:
+            report.append("MOST EVALUATED MODIFIERS:")
+            sorted_modifiers = sorted(self.modifier_evaluations.items(), key=lambda x: x[1], reverse=True)
+            for mod_key, count in sorted_modifiers[:20]:  # Top 20
+                report.append(f"  {mod_key}: {count} evaluations")
+            report.append("")
+        
+        # Full log
+        report.append("FULL LOG:")
+        report.extend(self.log_entries)
+        
+        return "\n".join(report)
+    
+    def save_to_text_block(self, name="NLA_Bake_Debug_Log"):
+        report = self.generate_report()
+        
+        # Create or update text block in Blender
+        if name in bpy.data.texts:
+            text_block = bpy.data.texts[name]
+            text_block.clear()
+        else:
+            text_block = bpy.data.texts.new(name)
+        
+        text_block.write(report)
+        return text_block
+
+# Global debugger instance
+_bake_debugger = BakeDebugger()
+
+# Monkey patch some Blender functions to intercept evaluations
+original_object_update = None
+original_modifier_update = None
+
+def debug_object_update(self, context, depsgraph):
+    """Intercept object updates during baking"""
+    if _jiggle_globals.jiggle_baking:
+        _bake_debugger.log_object_evaluation(self.name, self.type)
+    
+    if original_object_update:
+        return original_object_update(self, context, depsgraph)
+
+@persistent
+def debug_frame_change_pre(scene, depsgraph):
+    """Log when frame changes during baking"""
+    if _jiggle_globals.jiggle_baking:
+        _bake_debugger.log_frame_start(scene.frame_current)
+
+@persistent  
+def debug_frame_change_post(scene, depsgraph):
+    """Log when frame processing completes during baking"""
+    if _jiggle_globals.jiggle_baking:
+        _bake_debugger.log_frame_end(scene.frame_current)
+        
+        # Log which objects were evaluated this frame
+        for obj in scene.objects:
+            # Check if object was recently evaluated by looking at its dependency graph
+            if hasattr(depsgraph, 'object_instances'):
+                for instance in depsgraph.object_instances:
+                    if instance.object == obj:
+                        _bake_debugger.log_object_evaluation(obj.name, obj.type)
+                        
+                        # Log modifiers on this object
+                        for modifier in obj.modifiers:
+                            if modifier.show_viewport:
+                                _bake_debugger.log_modifier_evaluation(obj.name, modifier.name, modifier.type)
+
+
 ZERO_VEC = Vector((0,0,0))
 IDENTITY_MAT = Matrix.Identity(4)
 IDENTITY_QUAT = Quaternion()
@@ -919,8 +1063,14 @@ class ARMATURE_OT_JiggleBake(Operator):
     def poll(cls,context):
         return context.object and context.mode == 'POSE' and context.object.type == 'ARMATURE' and context.object.jiggle.enable and not context.object.jiggle.mute
     
-    def execute(self,context):
-        global _jiggle_globals
+    # Modified ARMATURE_OT_JiggleBake.execute() method with debugging
+    def execute(self, context):
+        global _jiggle_globals, _bake_debugger
+        
+        # Start debug logging
+        _bake_debugger.start_logging()
+        _bake_debugger.log(f"Starting bake for object: {context.object.name}")
+        
         _jiggle_globals.jiggle_baking = True
 
         bone_collections = context.object.data.collections
@@ -939,6 +1089,14 @@ class ARMATURE_OT_JiggleBake(Operator):
                 track.strips.new(action.name, int(action.frame_range[0]), action)
                 
             push_nla()
+            
+            # Log scene state before optimization
+            visible_objects = [obj for obj in context.scene.objects if not obj.hide_viewport]
+            _bake_debugger.log(f"Visible objects before optimization: {len(visible_objects)}")
+            for obj in visible_objects:
+                active_modifiers = [mod for mod in obj.modifiers if mod.show_viewport]
+                if active_modifiers:
+                    _bake_debugger.log(f"  {obj.name} ({obj.type}): {len(active_modifiers)} active modifiers")
             
             #preroll
             duration = context.scene.frame_end - context.scene.frame_start
@@ -962,13 +1120,15 @@ class ARMATURE_OT_JiggleBake(Operator):
                 virtual_particles = get_virtual_particles(context.scene)
                 jiggle_simulate(context.scene, context.evaluated_depsgraph_get(), virtual_particles, context.scene.jiggle.preroll)
             
-            #bake - OPTIMIZE THE SCENE FOR FASTER EVALUATION
+            #bake 
             if context.scene.use_preview_range:
                 frame_start = context.scene.frame_preview_start
                 frame_end = context.scene.frame_preview_end
             else:
                 frame_start = context.scene.frame_start
                 frame_end = context.scene.frame_end
+            
+            _bake_debugger.log(f"Baking frames {frame_start} to {frame_end}")
             
             # Store original states to restore later
             hidden_objects = []
@@ -985,6 +1145,10 @@ class ARMATURE_OT_JiggleBake(Operator):
                             for coll_obj in bone.jiggle.collider_collection.objects:
                                 collision_objects.add(coll_obj)
 
+            _bake_debugger.log(f"Found {len(collision_objects)} collision objects")
+            for obj in collision_objects:
+                _bake_debugger.log(f"  Collision object: {obj.name} ({obj.type})")
+
             # Aggressively optimize the scene
             for obj in context.scene.objects:
                 # Keep armatures, empties, and collision objects visible
@@ -994,13 +1158,14 @@ class ARMATURE_OT_JiggleBake(Operator):
                         for modifier in obj.modifiers:
                             if modifier.type in ['NODES', 'SUBSURF', 'MULTIRES', 'FLUID', 'CLOTH', 'SOFT_BODY', 'OCEAN', 'DYNAMIC_PAINT']:
                                 if modifier.show_viewport:
+                                    _bake_debugger.log(f"Disabling modifier {modifier.name} on collision object {obj.name}")
                                     disabled_modifiers.append((obj, modifier))
                                     modifier.show_viewport = False
                     continue
                     
                 # For everything else: disable modifiers first, then hide
                 else:
-                    # Disable all modifiers on objects we're about to hide (just to be extra safe)
+                    # Disable all modifiers on objects we're about to hide
                     for modifier in obj.modifiers:
                         if modifier.show_viewport:
                             disabled_modifiers.append((obj, modifier))
@@ -1011,7 +1176,16 @@ class ARMATURE_OT_JiggleBake(Operator):
                         hidden_objects.append(obj)
                         obj.hide_viewport = True
 
+            # Log final scene state
+            final_visible_objects = [obj for obj in context.scene.objects if not obj.hide_viewport]
+            _bake_debugger.log(f"Visible objects after optimization: {len(final_visible_objects)}")
+            _bake_debugger.log(f"Hidden objects: {len(hidden_objects)}")
+            _bake_debugger.log(f"Disabled modifiers: {len(disabled_modifiers)}")
+            
             try:
+                _bake_debugger.log("Starting bpy.ops.nla.bake()...")
+                bake_start_time = time.time()
+                
                 # Use the original NLA baking but with aggressively optimized scene
                 bpy.ops.nla.bake(frame_start = frame_start,
                                 frame_end = frame_end,
@@ -1020,8 +1194,13 @@ class ARMATURE_OT_JiggleBake(Operator):
                                 use_current_action = context.scene.jiggle.bake_overwrite,
                                 bake_types={'POSE'},
                                 channel_types={'LOCATION','ROTATION','SCALE'})
+                
+                bake_duration = time.time() - bake_start_time
+                _bake_debugger.log(f"bpy.ops.nla.bake() completed in {bake_duration:.3f}s")
+                
             finally:
                 # Restore scene state
+                _bake_debugger.log("Restoring scene state...")
                 for obj in hidden_objects:
                     obj.hide_viewport = False
                 
@@ -1040,6 +1219,12 @@ class ARMATURE_OT_JiggleBake(Operator):
                 col.is_solo = collection_solo[col.name]
                 col.is_visible = collection_visibility[col.name]
             _jiggle_globals.jiggle_baking = False
+            
+            # Generate and save debug report
+            _bake_debugger.log("=== BAKE COMPLETE ===")
+            text_block = _bake_debugger.save_to_text_block()
+            _bake_debugger.log(f"Debug report saved to text block: {text_block.name}")
+        
         return {'FINISHED'}
 
 class JigglePanel:
@@ -1642,6 +1827,10 @@ def register():
     bpy.app.handlers.animation_playback_pre.append(jiggle_playback_start)
     bpy.app.handlers.animation_playback_post.append(jiggle_playback_end)
 
+    # Debugging for NLA Bake
+    bpy.app.handlers.frame_change_pre.append(debug_frame_change_pre)
+    bpy.app.handlers.frame_change_post.append(debug_frame_change_post)
+
 def unregister():
     bpy.utils.unregister_class(JiggleBone)
     bpy.utils.unregister_class(JiggleObject)
@@ -1678,6 +1867,10 @@ def unregister():
     bpy.app.handlers.render_cancel.remove(jiggle_render_cancel)
     bpy.app.handlers.animation_playback_pre.remove(jiggle_playback_start)
     bpy.app.handlers.animation_playback_post.remove(jiggle_playback_end)
+
+    # Debugging for NLA Bake
+    bpy.app.handlers.frame_change_pre.remove(debug_frame_change_pre)
+    bpy.app.handlers.frame_change_post.remove(debug_frame_change_post)
 
     global _jiggle_globals
     _jiggle_globals.on_unregister()

--- a/__init__.py
+++ b/__init__.py
@@ -742,7 +742,7 @@ def jiggle_render_post(scene):
 def jiggle_render_cancel(scene):
     global _jiggle_globals
     _jiggle_globals.is_rendering = False
-            
+
 class ARMATURE_OT_JiggleCopy(Operator):
     """Copy active jiggle settings to selected bones"""
     bl_idname = "armature.jiggle_copy"
@@ -907,7 +907,8 @@ class ARMATURE_OT_JiggleSelect(Operator):
     def execute(self,context):
         jiggle_select(context)
         return {'FINISHED'}
-    
+
+
 class ARMATURE_OT_JiggleBake(Operator):
     """Bake this object's visible jiggle bones to keyframes"""
     bl_idname = "armature.jiggle_bake"
@@ -960,30 +961,86 @@ class ARMATURE_OT_JiggleBake(Operator):
                 _jiggle_globals.is_preroll = True
                 virtual_particles = get_virtual_particles(context.scene)
                 jiggle_simulate(context.scene, context.evaluated_depsgraph_get(), virtual_particles, context.scene.jiggle.preroll)
-            #bake
+            
+            #bake - OPTIMIZE THE SCENE FOR FASTER EVALUATION
             if context.scene.use_preview_range:
                 frame_start = context.scene.frame_preview_start
                 frame_end = context.scene.frame_preview_end
             else:
                 frame_start = context.scene.frame_start
                 frame_end = context.scene.frame_end
-            bpy.ops.nla.bake(frame_start = frame_start,
-                            frame_end = frame_end,
-                            only_selected = True,
-                            visual_keying = True,
-                            use_current_action = context.scene.jiggle.bake_overwrite,
-                            bake_types={'POSE'},
-                            channel_types={'LOCATION','ROTATION','SCALE'})
+            
+            # Store original states to restore later
+            hidden_objects = []
+            disabled_modifiers = []
+
+            # Get all collision objects that must remain functional
+            collision_objects = set()
+            for armature_obj in [o for o in context.scene.objects if o.type == 'ARMATURE']:
+                for bone in armature_obj.pose.bones:
+                    if hasattr(bone, 'jiggle') and bone.jiggle.enable:
+                        if bone.jiggle.collider_type == 'Object' and bone.jiggle.collider:
+                            collision_objects.add(bone.jiggle.collider)
+                        elif bone.jiggle.collider_type == 'Collection' and bone.jiggle.collider_collection:
+                            for coll_obj in bone.jiggle.collider_collection.objects:
+                                collision_objects.add(coll_obj)
+
+            # Aggressively optimize the scene
+            for obj in context.scene.objects:
+                # Keep armatures, empties, and collision objects visible
+                if obj.type in ['ARMATURE', 'EMPTY'] or obj in collision_objects:
+                    # But still disable expensive modifiers on collision objects
+                    if obj in collision_objects:
+                        for modifier in obj.modifiers:
+                            if modifier.type in ['NODES', 'SUBSURF', 'MULTIRES', 'FLUID', 'CLOTH', 'SOFT_BODY', 'OCEAN', 'DYNAMIC_PAINT']:
+                                if modifier.show_viewport:
+                                    disabled_modifiers.append((obj, modifier))
+                                    modifier.show_viewport = False
+                    continue
+                    
+                # For everything else: disable modifiers first, then hide
+                else:
+                    # Disable all modifiers on objects we're about to hide (just to be extra safe)
+                    for modifier in obj.modifiers:
+                        if modifier.show_viewport:
+                            disabled_modifiers.append((obj, modifier))
+                            modifier.show_viewport = False
+                    
+                    # Then hide the object
+                    if not obj.hide_viewport:
+                        hidden_objects.append(obj)
+                        obj.hide_viewport = True
+
+            try:
+                # Use the original NLA baking but with aggressively optimized scene
+                bpy.ops.nla.bake(frame_start = frame_start,
+                                frame_end = frame_end,
+                                only_selected = True,
+                                visual_keying = True,  # This is necessary for jiggle physics!
+                                use_current_action = context.scene.jiggle.bake_overwrite,
+                                bake_types={'POSE'},
+                                channel_types={'LOCATION','ROTATION','SCALE'})
+            finally:
+                # Restore scene state
+                for obj in hidden_objects:
+                    obj.hide_viewport = False
+                
+                for obj, modifier in disabled_modifiers:
+                    modifier.show_viewport = True
+            
             _jiggle_globals.is_preroll = False
             context.object.jiggle.freeze = True
+            
             if not context.scene.jiggle.bake_overwrite:
-                context.object.animation_data.action.name = 'JiggleAction'
+                if context.object.animation_data and context.object.animation_data.action:
+                    context.object.animation_data.action.name = 'JiggleAction'
+            
         finally:
             for col in bone_collections:
                 col.is_solo = collection_solo[col.name]
                 col.is_visible = collection_visibility[col.name]
             _jiggle_globals.jiggle_baking = False
-        return {'FINISHED'}  
+        return {'FINISHED'}
 
 class JigglePanel:
     bl_category = 'Animation'

--- a/__init__.py
+++ b/__init__.py
@@ -1063,7 +1063,7 @@ class ARMATURE_OT_JiggleBake(Operator):
     def poll(cls,context):
         return context.object and context.mode == 'POSE' and context.object.type == 'ARMATURE' and context.object.jiggle.enable and not context.object.jiggle.mute
     
-    # Modified ARMATURE_OT_JiggleBake.execute() method with debugging
+    # Modified ARMATURE_OT_JiggleBake.execute() method with debugging. This version applies optimizations earlier:
     def execute(self, context):
         global _jiggle_globals, _bake_debugger
         
@@ -1076,6 +1076,10 @@ class ARMATURE_OT_JiggleBake(Operator):
         bone_collections = context.object.data.collections
         collection_visibility = {col.name: col.is_visible for col in bone_collections}
         collection_solo = {col.name: col.is_solo for col in bone_collections}
+
+        # Store original states to restore later - MOVED UP EARLY
+        hidden_objects = []
+        disabled_modifiers = []
 
         try:
             def push_nla():
@@ -1097,43 +1101,8 @@ class ARMATURE_OT_JiggleBake(Operator):
                 active_modifiers = [mod for mod in obj.modifiers if mod.show_viewport]
                 if active_modifiers:
                     _bake_debugger.log(f"  {obj.name} ({obj.type}): {len(active_modifiers)} active modifiers")
-            
-            #preroll
-            duration = context.scene.frame_end - context.scene.frame_start
-            _jiggle_globals.is_preroll = False
 
-            for col in bone_collections:
-                col.is_solo = False
-                col.is_visible = True
-
-            bpy.ops.pose.select_all(action='DESELECT')
-            jiggle_select(context)
-            jiggle_reset(context)
-            if context.scene.jiggle.loop:
-                for preroll in reversed(range(context.scene.jiggle.preroll)):
-                    frame = context.scene.frame_end - (preroll%duration)
-                    context.scene.frame_set(frame)
-                    _jiggle_globals.is_preroll = True
-            else:
-                context.scene.frame_set(context.scene.frame_start)
-                _jiggle_globals.is_preroll = True
-                virtual_particles = get_virtual_particles(context.scene)
-                jiggle_simulate(context.scene, context.evaluated_depsgraph_get(), virtual_particles, context.scene.jiggle.preroll)
-            
-            #bake 
-            if context.scene.use_preview_range:
-                frame_start = context.scene.frame_preview_start
-                frame_end = context.scene.frame_preview_end
-            else:
-                frame_start = context.scene.frame_start
-                frame_end = context.scene.frame_end
-            
-            _bake_debugger.log(f"Baking frames {frame_start} to {frame_end}")
-            
-            # Store original states to restore later
-            hidden_objects = []
-            disabled_modifiers = []
-
+            # APPLY OPTIMIZATIONS EARLY - BEFORE PREROLL!
             # Get all collision objects that must remain functional
             collision_objects = set()
             for armature_obj in [o for o in context.scene.objects if o.type == 'ARMATURE']:
@@ -1149,7 +1118,7 @@ class ARMATURE_OT_JiggleBake(Operator):
             for obj in collision_objects:
                 _bake_debugger.log(f"  Collision object: {obj.name} ({obj.type})")
 
-            # Aggressively optimize the scene
+            # Aggressively optimize the scene BEFORE preroll
             for obj in context.scene.objects:
                 # Keep armatures, empties, and collision objects visible
                 if obj.type in ['ARMATURE', 'EMPTY'] or obj in collision_objects:
@@ -1176,36 +1145,62 @@ class ARMATURE_OT_JiggleBake(Operator):
                         hidden_objects.append(obj)
                         obj.hide_viewport = True
 
-            # Log final scene state
+            # Log final scene state after early optimization
             final_visible_objects = [obj for obj in context.scene.objects if not obj.hide_viewport]
-            _bake_debugger.log(f"Visible objects after optimization: {len(final_visible_objects)}")
+            _bake_debugger.log(f"Visible objects after EARLY optimization: {len(final_visible_objects)}")
             _bake_debugger.log(f"Hidden objects: {len(hidden_objects)}")
             _bake_debugger.log(f"Disabled modifiers: {len(disabled_modifiers)}")
             
-            try:
-                _bake_debugger.log("Starting bpy.ops.nla.bake()...")
-                bake_start_time = time.time()
-                
-                # Use the original NLA baking but with aggressively optimized scene
-                bpy.ops.nla.bake(frame_start = frame_start,
-                                frame_end = frame_end,
-                                only_selected = True,
-                                visual_keying = True,  # This is necessary for jiggle physics!
-                                use_current_action = context.scene.jiggle.bake_overwrite,
-                                bake_types={'POSE'},
-                                channel_types={'LOCATION','ROTATION','SCALE'})
-                
-                bake_duration = time.time() - bake_start_time
-                _bake_debugger.log(f"bpy.ops.nla.bake() completed in {bake_duration:.3f}s")
-                
-            finally:
-                # Restore scene state
-                _bake_debugger.log("Restoring scene state...")
-                for obj in hidden_objects:
-                    obj.hide_viewport = False
-                
-                for obj, modifier in disabled_modifiers:
-                    modifier.show_viewport = True
+            # Now do preroll with optimized scene
+            duration = context.scene.frame_end - context.scene.frame_start
+            _jiggle_globals.is_preroll = False
+
+            for col in bone_collections:
+                col.is_solo = False
+                col.is_visible = True
+
+            bpy.ops.pose.select_all(action='DESELECT')
+            jiggle_select(context)
+            jiggle_reset(context)
+            
+            _bake_debugger.log("Starting preroll with optimized scene...")
+            if context.scene.jiggle.loop:
+                for preroll in reversed(range(context.scene.jiggle.preroll)):
+                    frame = context.scene.frame_end - (preroll%duration)
+                    context.scene.frame_set(frame)
+                    _jiggle_globals.is_preroll = True
+            else:
+                context.scene.frame_set(context.scene.frame_start)
+                _jiggle_globals.is_preroll = True
+                virtual_particles = get_virtual_particles(context.scene)
+                jiggle_simulate(context.scene, context.evaluated_depsgraph_get(), virtual_particles, context.scene.jiggle.preroll)
+            
+            _bake_debugger.log("Preroll completed, starting actual bake...")
+            
+            #bake 
+            if context.scene.use_preview_range:
+                frame_start = context.scene.frame_preview_start
+                frame_end = context.scene.frame_preview_end
+            else:
+                frame_start = context.scene.frame_start
+                frame_end = context.scene.frame_end
+            
+            _bake_debugger.log(f"Baking frames {frame_start} to {frame_end}")
+            
+            _bake_debugger.log("Starting bpy.ops.nla.bake()...")
+            bake_start_time = time.time()
+            
+            # Use the original NLA baking with already-optimized scene
+            bpy.ops.nla.bake(frame_start = frame_start,
+                            frame_end = frame_end,
+                            only_selected = True,
+                            visual_keying = True,  # This is necessary for jiggle physics!
+                            use_current_action = context.scene.jiggle.bake_overwrite,
+                            bake_types={'POSE'},
+                            channel_types={'LOCATION','ROTATION','SCALE'})
+            
+            bake_duration = time.time() - bake_start_time
+            _bake_debugger.log(f"bpy.ops.nla.bake() completed in {bake_duration:.3f}s")
             
             _jiggle_globals.is_preroll = False
             context.object.jiggle.freeze = True
@@ -1215,6 +1210,14 @@ class ARMATURE_OT_JiggleBake(Operator):
                     context.object.animation_data.action.name = 'JiggleAction'
             
         finally:
+            # Restore scene state
+            _bake_debugger.log("Restoring scene state...")
+            for obj in hidden_objects:
+                obj.hide_viewport = False
+            
+            for obj, modifier in disabled_modifiers:
+                modifier.show_viewport = True
+                
             for col in bone_collections:
                 col.is_solo = collection_solo[col.name]
                 col.is_visible = collection_visibility[col.name]
@@ -1226,6 +1229,7 @@ class ARMATURE_OT_JiggleBake(Operator):
             _bake_debugger.log(f"Debug report saved to text block: {text_block.name}")
         
         return {'FINISHED'}
+
 
 class JigglePanel:
     bl_category = 'Animation'


### PR DESCRIPTION
# Jiggle Physics Baking Performance Optimization

| Property | Value |
|----------|-------|
| Date: | 2025-08-06 |
| Version: | Tested with Blender 4.5.0 LTS |

I'm attempting to diagnose a problem in this blender extension/addon.

The jiggle physics work for the most part. My only major problem so far is the baking logic. In my production Blend file, trying to bake the jiggle bones causes CPU to throttle at 100% for over an hour. The baking process is incredibly intensive and takes a long long time.

I have a theory on why this was happening, so I tested my hypothesis. My theory is that for some reason, the Jiggle Physics addon is recalculating the entire scene (all objects, all their modifiers, geonodes, everything) when it is baking each frame. This is incredibly unnecessary, as the only objects that should need to be calculated each frame are the armature itself and any collections/objects designated as collision in the addon panel.

My main production animation scene is quite complex with lots of modifiers and custom geometry node setups. So to test my theory I started a new blank blender file, and appended just the relevant armature and its actions. No meshes, no cameras, nothing else. When I use the Jiggle Physics addon to bake this scene, it bakes nearly instantly. So my theory is likely correct that the addon is recalculating EVERYTHING in a scene, which is overkill.

My final results are revealed at the bottom, but overall I'm seeing between a 100x and 300x performance boost, depending on the complexity of the scene.


## Problem Identification
- **Initial Issue**: Blender Jiggle Physics addon baking was extremely slow in production scenes with lots of complex modifiers, geometry, and nodes.
- **Symptoms**: 
  - Simple Test scene (2 armatures only): Fast baking, only a few seconds to bake.
  - Full Production scene (using those same 2 armatures + complex geometry/modifiers): 30 to 60 minutes to bake a short sequence.
  - Theory: I think the addon is recalculating the entire scene every frame during baking (including ALL geometry nodes, modifiers, meshes, etc).


## Investigation Process
### Step 1: Understanding the Root Cause
- Identified that `bpy.ops.nla.bake(visual_keying=True)` was the bottleneck.
- `visual_keying=True` forces Blender to evaluate the entire dependency graph for every frame.
- This includes all modifiers, geometry nodes, materials, and scene objects.
- The **Jiggle Physics** addon only needs armatures and collision objects, not the entire scene. Let's see if we can remove unnecessary objects from scene evaluation.

### Step 2: Apply the Correct Approach - Scene Context Optimization
- Optimize the NLA baking system, by limiting what gets evaluated during the NLA baking process.
- **Strategy**: Temporarily hide/disable expensive scene elements while keeping essential jiggle objects functional.
  - **Result**: I saw minor bake time improvements, but not major. This means *something* about my approach was working, but not fully.
  - **Next Step**: Implement some sort of NLA Baker debugger log so I can see where the bottleneck is.

### Step 3: Debugging and Analysis
- I implemented a comprehensive NLA Bake logging system to track exactly what was being evaluated, and how long each frame and each step was taking.
- **Critical discovery**:
  - There was a strange bottleneck right before the Bake process started. Some frames were being simulated, but very very slow (11+ seconds each).
  - Full Production scene: Only 3% of the NLA operation time was spent in `bpy.ops.nla.bake()`, 97% of effort was in the preroll phase.
- **Root cause identified**: Optimizations were applied too late. I had applied scene optimization to the bake phase, but the preroll phase was still evaluating the full scene, causing slow down.


## Final Solution
### Optimization Strategy
1. **Early scene optimization** - Apply aggressive optimization BEFORE preroll simulation, to improve baking speed.
2. **Aggressive object hiding** - Hide all non-essential objects:
   - *Keep*: Armatures, empties, designated collision objects.
   - *Hide*: All meshes, curves, lights, cameras (except collision objects).
3. **Modifier disabling** - Disable expensive modifiers even on remaining visible objects:
   - *Disabled*: Geometry Nodes, Subdivision, Multiresolution, Fluid, Cloth, etc. -- *everything non-essential!*

## Results
### Performance Improvements
I did not have a proper debugger implemented before my initial optimization, so the improvements recorded here are actually on the lower estimate side. But these are the results I got when implementing the initial bake optimizations, and then the final result when I moved the optimization steps to before the preroll phase.

#### **Test Production scene (48 frames)**:
Just a small 2 second sample from my main production scene.

| Test Phase | Results |
|------------|---------|
| Before Any Optimization: | (Several minutes bake time) |
| Before Preroll Optimization: | 73.549s bake time |
| After Preroll Optimization: | 3.247s bake time |
| **Improvement:** | **22.65x faster** at minimum |

#### **Real Production scene (456 frames)**:
The full timeline of my production scene.

| Test Phase | Results |
|------------|---------|
| Before Any Optimization: | (Several hours bake time) |
| Before Preroll Optimization: | 2150.506s (35+ minutes) bake time |
| Afte Preroll Optimization: | 19.965s bake time |
| **Improvement:** | **113x faster** at minimum |

### Technical Insights
- Jiggle physics modifies bone matrices directly via `VirtualParticle.apply_pose()`.
- `visual_keying=True` is required to capture these modifications in keyframes.
- Blender's dependency graph evaluation can be selectively optimized without breaking functionality of the Jiggle addon.
- Bake and Preroll simulation was consuming most of the time in complex scenes due to full scene evaluation.

## Final Process
The optimized baking process now:
1. Analyzes scene to identify essential objects (armatures + collision objects)
2. **Early optimization**: Hides non-essential objects and disables expensive modifiers
3. Runs preroll simulation with optimized scene
4. Executes `bpy.ops.nla.bake(visual_keying=True)` with optimized scene
5. Restores original scene state

This maintains full jiggle physics functionality while achieving 100x+ performance improvements in complex production scenes.

---

# Notes:
- I did not test this with bone collisions, as my scene did not require them. But there should be no issues in the logic, as the collision objects are specifically gathered and included in the Bake process.
- Further testing with collisions will be needed in the near future.
- The core baking logic wasn't really modified, so there should be no conflicts.
- Currently, this change simply gathers ALL armatures with jiggle physics enabled, and ALL collections/objects designated as collision. It could in theory be optimized further to only gather currently selected armatures, but I think this is so far a good first step.
- Overall, these improvements should be incorporated as soon as possible, as they save precious compute time and energy. Especially since the bake process seems to heavily rely on the slower CPU rather than GPU to do its work.
