### PR TITLE
Fix #43: Handle Slotted Actions parameter keyframe clearing for Blender 5.0+

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1337,9 +1337,19 @@ class ANIM_OT_JiggleClearKeyframes(Operator):
         for bone in context.selected_pose_bones:
             for prop in ['jiggle_root_elasticity', 'jiggle_angle_elasticity', 'jiggle_length_elasticity', 'jiggle_elasticity_soften', 'jiggle_gravity', 'jiggle_blend', 'jiggle_air_drag', 'jiggle_friction', 'jiggle_collision_radius']:
                 data_path = f'pose.bones["{bone.name}"].{prop}'
-                fcurves_to_remove = [fc for fc in action.fcurves if fc.data_path == data_path]
-                for fc in fcurves_to_remove:
-                    action.fcurves.remove(fc)
+                if hasattr(action, 'fcurves'):
+                    fcurves_to_remove = [fc for fc in action.fcurves if fc.data_path == data_path]
+                    for fc in fcurves_to_remove:
+                        action.fcurves.remove(fc)
+                elif hasattr(context.object.animation_data, 'action_slot'):
+                    slot = context.object.animation_data.action_slot
+                    if slot:
+                        from bpy_extras import anim_utils
+                        channelbag = anim_utils.action_get_channelbag_for_slot(action, slot)
+                        if channelbag and hasattr(channelbag, 'fcurves'):
+                            fcurves_to_remove = [fc for fc in channelbag.fcurves if fc.data_path == data_path]
+                            for fc in fcurves_to_remove:
+                                channelbag.fcurves.remove(fc)
         return {'FINISHED'}
 
 class SCENE_OT_JiggleProfile(Operator):


### PR DESCRIPTION
### Description
This PR fixes the `AttributeError: 'Action' object has no attribute 'fcurves' `error that occurs when clicking the **"Clear Parameter Keyframes"** button in Blender 5.0+.

### Cause of the Error
Blender's recent animation system overhaul (Project Gold) introduced "Slotted Actions". Because of this, animation F-Curves are no longer attached directly to the base `Action` object, breaking the add-on's original keyframe-clearing logic.

### How it is fixed

- Maintained legacy support for older Blender versions by first checking if `action.fcurves` exists.

- For Blender 5.0+, the script now utilizes the officially recommended `bpy_extras.anim_utils.action_get_channelbag_for_slot() `safely grab the F-Curves from the active channel bag.